### PR TITLE
Reproduce and fix Argument 2 passed to Sentry\FrameBuilder::buildFrom…

### DIFF
--- a/src/Http/SentryClient.php
+++ b/src/Http/SentryClient.php
@@ -228,13 +228,13 @@ class SentryClient
     }
 
     /**
-     * @param array<array<string, int|string>> $traces
-     * @return array<array<string, int>>
+     * @param array<array<string, null|int|string|array>> $traces
+     * @return array<array<string, null|int|string|array>>
      */
     private function cleanedTrace(array $traces): array
     {
         foreach ($traces as $key => $trace) {
-            if (isset($trace['line']) && is_string($trace['line'])) {
+            if (isset($trace['line']) && $trace['line'] === '??') {
                 $traces[$key]['line'] = 0;
             }
         }

--- a/src/Http/SentryClient.php
+++ b/src/Http/SentryClient.php
@@ -200,7 +200,7 @@ class SentryClient
             if ($client) {
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $stacktrace = $client->getStacktraceBuilder()
-                    ->buildFromBacktrace($this->cleanedTrace($error->getTrace()), $error->getFile() ?? 'unknown file', $error->getLine() ?? 0);
+                ->buildFromBacktrace($this->cleanedTrace($error->getTrace()), $error->getFile() ?? 'unknown file', $error->getLine() ?? 0);
                 $hint = EventHint::fromArray([
                 'stacktrace' => $stacktrace,
                 ]);

--- a/src/Http/SentryClient.php
+++ b/src/Http/SentryClient.php
@@ -200,7 +200,7 @@ class SentryClient
             if ($client) {
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $stacktrace = $client->getStacktraceBuilder()
-                ->buildFromBacktrace($error->getTrace(), $error->getFile() ?? 'unknown file', $error->getLine() ?? 0);
+                    ->buildFromBacktrace($this->cleanedTrace($error->getTrace()), $error->getFile() ?? 'unknown file', $error->getLine() ?? 0);
                 $hint = EventHint::fromArray([
                 'stacktrace' => $stacktrace,
                 ]);
@@ -224,5 +224,19 @@ class SentryClient
     public function getHub(): ?HubInterface
     {
         return $this->hub;
+    }
+
+    /**
+     * @param array<array<string, int|string>> $traces
+     * @return array<array<string, int|string>>
+     */
+    private function cleanedTrace(array $traces): array
+    {
+        foreach($traces as $key => $trace) {
+            if (isset($trace['line']) && $trace['line'] === '??') {
+                $traces[$key]['line'] = 0;
+            }
+        }
+        return $traces;
     }
 }

--- a/src/Http/SentryClient.php
+++ b/src/Http/SentryClient.php
@@ -198,9 +198,10 @@ class SentryClient
         if ($this->hub) {
             $client = $this->hub->getClient();
             if ($client) {
+                $trace = $this->cleanedTrace($error->getTrace());
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $stacktrace = $client->getStacktraceBuilder()
-                ->buildFromBacktrace($this->cleanedTrace($error->getTrace()), $error->getFile() ?? 'unknown file', $error->getLine() ?? 0);
+                ->buildFromBacktrace($trace, $error->getFile() ?? 'unknown file', $error->getLine() ?? 0);
                 $hint = EventHint::fromArray([
                 'stacktrace' => $stacktrace,
                 ]);
@@ -228,15 +229,16 @@ class SentryClient
 
     /**
      * @param array<array<string, int|string>> $traces
-     * @return array<array<string, int|string>>
+     * @return array<array<string, int>>
      */
     private function cleanedTrace(array $traces): array
     {
-        foreach($traces as $key => $trace) {
-            if (isset($trace['line']) && $trace['line'] === '??') {
+        foreach ($traces as $key => $trace) {
+            if (isset($trace['line']) && is_string($trace['line'])) {
                 $traces[$key]['line'] = 0;
             }
         }
+
         return $traces;
     }
 }

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -161,6 +161,30 @@ final class ClientTest extends TestCase
     }
 
     /**
+     * Test capture error with unknown lines '??'
+     */
+    public function testCaptureErrorWithUnknownLines(): void
+    {
+        $subject = new SentryClient([]);
+        $options = new Options();
+        $clientBuilder = new ClientBuilder($options);
+        $client = $clientBuilder->getClient();
+        $subject->getHub()->bindClient($client);
+
+        $trace = [
+            [
+                'file' => '[internal]',
+                'line' => '??',
+            ]
+        ];
+        $error = new PhpError(E_USER_WARNING, 'something wrong.', '/my/app/path/test.php', 123, $trace);
+        $subject->captureError($error);
+
+        $result = $client->captureMessage($error->getMessage());
+        $this->assertInstanceOf(EventId::class, $result);
+    }
+
+    /**
      * Test capture exception pass cakephp-log's context as additional data
      */
     public function testCaptureExceptionWithAdditionalData(): void

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -175,7 +175,7 @@ final class ClientTest extends TestCase
             [
                 'file' => '[internal]',
                 'line' => '??',
-            ]
+            ],
         ];
         $error = new PhpError(E_USER_WARNING, 'something wrong.', '/my/app/path/test.php', 123, $trace);
         $subject->captureError($error);


### PR DESCRIPTION
…BacktraceFrame() must be of the type int, string given

closes https://github.com/LordSimal/cakephp-sentry/issues/1

includes
- test to reproduce (this test will fail on the current master)
- fix (iterate replace line='??' for line=0)