### PR TITLE
3.x fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at https://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.neon]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+# Set the default behavior for all files.
+* text=auto
+
 .gitattributes export-ignore
 .gitignore export-ignore
 .travis.yml export-ignore

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ CakePHP integration for Sentry.
 - PHP 8.1+
 - CakePHP 5+
 - and a [Sentry](https://sentry.io) account
-  - if you use self hosted sentry make sure you are on at least version `>= v20.6.0` 
+  - if you use self-hosted sentry make sure you are on at least version `>= v20.6.0`
 
 ## Version table
 |     | PHP              | CakePHP | self-hosted Sentry |
@@ -82,7 +82,7 @@ You can filter out noisy exceptions which should not be debugged further.
 Also see [CakePHP Cookbook](https://book.cakephp.org/4/en/development/errors.html#error-exception-configuration)
 
 ### Set Options
-Everything inside the `'Sentry'` configuration key will be passed to `\Sentry\init()`.  
+Everything inside the `'Sentry'` configuration key will be passed to `\Sentry\init()`.
 Please check Sentry's official documentation on [about configuration](https://docs.sentry.io/error-reporting/configuration/?platform=php) and [about php-sdk's configuraion](https://docs.sentry.io/platforms/php/#php-specific-options).
 
 CakeSentry also provides custom event hooks to set dynamic values.
@@ -101,7 +101,7 @@ use Cake\Event\EventListenerInterface;
 
 class SentryOptionsContext implements EventListenerInterface
 {
-    public function implementedEvents(): array  
+    public function implementedEvents(): array
     {
         return [
             'CakeSentry.Client.afterSetup' => 'setServerContext',

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     },
     "scripts": {
         "test": "phpunit",
-        "cs-check": "phpcs --colors -p src tests",
-        "cs-fix": "phpcbf --colors -p src tests",
+        "cs-check": "phpcs --colors -p src/ tests/",
+        "cs-fix": "phpcbf --colors -p src/ tests/",
         "phpstan": "tools/phpstan analyse",
         "psalm": "tools/psalm --show-info=false",
         "stan": [

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,7 @@
 parameters:
-    paths:
-      - src
-      - tests/TestCase
-    level: 5
-    bootstrapFiles:
-      - tests/bootstrap.php
+	paths:
+		- src/
+	level: 5
+	checkMissingIterableValueType: false
+	bootstrapFiles:
+		- tests/bootstrap.php

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,14 +10,14 @@
 
     <testsuites>
         <testsuite name="cakephp">
-            <directory>./tests/TestCase/</directory>
+            <directory>tests/TestCase/</directory>
         </testsuite>
     </testsuites>
 
     <!-- Prevent coverage reports from looking in tests, vendors, config folders -->
     <source>
         <include>
-            <directory suffix=".php">./src/</directory>
+            <directory suffix=".php">src/</directory>
         </include>
     </source>
 </phpunit>

--- a/src/Http/SentryClient.php
+++ b/src/Http/SentryClient.php
@@ -57,7 +57,9 @@ class SentryClient implements EventDispatcherInterface
             if ($connection->configName() === 'debug_kit') {
                 continue;
             }
-            $logger = $connection->getDriver()->getLogger();
+            /** @var \Cake\Database\Driver $driver */
+            $driver = $connection->getDriver();
+            $logger = $driver->getLogger();
 
             if ($logger instanceof CakeSentryLog) {
                 $logger->setIncludeSchema($includeSchemaReflection);
@@ -161,6 +163,7 @@ class SentryClient implements EventDispatcherInterface
 
         $client = $this->hub->getClient();
         if ($client) {
+            /** @var array<int, array{function?: string, line?: int, file?: string, class?: class-string, type?: string, args?: array}> $trace */
             $trace = $this->cleanedTrace($error->getTrace());
             /** @psalm-suppress ArgumentTypeCoercion */
             $stacktrace = $client->getStacktraceBuilder()

--- a/src/Middleware/CakeSentryPerformanceMiddleware.php
+++ b/src/Middleware/CakeSentryPerformanceMiddleware.php
@@ -110,9 +110,10 @@ class CakeSentryPerformanceMiddleware implements MiddlewareInterface
                 continue;
             }
             $logger = null;
+            /** @var \Cake\Database\Driver $driver */
             $driver = $connection->getDriver();
             $driverConfig = $driver->config();
-            if ($driverConfig['sentryLog']) {
+            if ($driverConfig['sentryLog'] ?? false) {
                 $logger = $driver->getLogger();
                 if ($logger instanceof CakeSentryLog) {
                     $logger->setPerformanceMonitoring(true);

--- a/src/Middleware/CakeSentryQueryMiddleware.php
+++ b/src/Middleware/CakeSentryQueryMiddleware.php
@@ -57,9 +57,10 @@ class CakeSentryQueryMiddleware implements MiddlewareInterface
                 continue;
             }
             $logger = null;
+            /** @var \Cake\Database\Driver $driver */
             $driver = $connection->getDriver();
             $driverConfig = $driver->config();
-            if ($driverConfig['sentryLog']) {
+            if ($driverConfig['sentryLog'] ?? false) {
                 $logger = $driver->getLogger();
             }
 

--- a/src/QuerySpanTrait.php
+++ b/src/QuerySpanTrait.php
@@ -60,8 +60,9 @@ trait QuerySpanTrait
         }
 
         if ($connectionName) {
-            $connection = ConnectionManager::get($connectionName);
-            $dialect = $connection->getDriver()->schemaDialect();
+            /** @var \Cake\Database\Driver $driver */
+            $driver = ConnectionManager::get($connectionName)->getDriver();
+            $dialect = $driver->schemaDialect();
             $type = match (true) {
                 $dialect instanceof PostgresSchemaDialect => 'postgresql',
                 $dialect instanceof SqliteSchemaDialect => 'sqlite',


### PR DESCRIPTION
I looked into the plugin and was wondering why it wouldnt default to false for the 

    $driverConfig['sentryLog'] ?? false

part, as this throws warnings, if you only set it on the default, but not on the test datasource.
Seems not necessary to have to do that.

As for the different configs:

I wonder if there couldnt be only one CakeSentry config instead of two first level ones.