### PR TITLE
fix: check driver is Cake Driver before trying to access

### DIFF
--- a/src/Http/SentryClient.php
+++ b/src/Http/SentryClient.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace CakeSentry\Http;
 
 use Cake\Core\Configure;
+use Cake\Database\Driver;
 use Cake\Datasource\ConnectionManager;
 use Cake\Error\PhpError;
 use Cake\Event\Event;
@@ -53,13 +54,17 @@ class SentryClient implements EventDispatcherInterface
         $includeSchemaReflection = (bool)Configure::read('CakeSentry.includeSchemaReflection');
 
         foreach ($configs as $name) {
+            $logger = null;
             $connection = ConnectionManager::get($name);
             if ($connection->configName() === 'debug_kit') {
                 continue;
             }
             /** @var \Cake\Database\Driver $driver */
             $driver = $connection->getDriver();
-            $logger = $driver->getLogger();
+
+            if ($driver instanceof Driver) {
+                $logger = $driver->getLogger();
+            }
 
             if ($logger instanceof CakeSentryLog) {
                 $logger->setIncludeSchema($includeSchemaReflection);

--- a/src/Middleware/CakeSentryPerformanceMiddleware.php
+++ b/src/Middleware/CakeSentryPerformanceMiddleware.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
  */
 namespace CakeSentry\Middleware;
 
+use Cake\Database\Driver;
 use Cake\Datasource\ConnectionManager;
 use Cake\Event\EventManager;
 use Cake\Http\Server;
@@ -121,11 +122,13 @@ class CakeSentryPerformanceMiddleware implements MiddlewareInterface
             $logger = null;
             /** @var \Cake\Database\Driver $driver */
             $driver = $connection->getDriver();
-            $driverConfig = $driver->config();
-            if ($driverConfig['sentryLog'] ?? false) {
-                $logger = $driver->getLogger();
-                if ($logger instanceof CakeSentryLog) {
-                    $logger->setPerformanceMonitoring(true);
+            if ($driver instanceof Driver) {
+                $driverConfig = $driver->config();
+                if ($driverConfig['sentryLog'] ?? false) {
+                    $logger = $driver->getLogger();
+                    if ($logger instanceof CakeSentryLog) {
+                        $logger->setPerformanceMonitoring(true);
+                    }
                 }
             }
         }

--- a/src/Middleware/CakeSentryQueryMiddleware.php
+++ b/src/Middleware/CakeSentryQueryMiddleware.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CakeSentry\Middleware;
 
 use Cake\Core\Configure;
+use Cake\Database\Driver;
 use Cake\Datasource\ConnectionManager;
 use CakeSentry\Database\Log\CakeSentryLog;
 use Psr\Http\Message\ResponseInterface;
@@ -59,9 +60,11 @@ class CakeSentryQueryMiddleware implements MiddlewareInterface
             $logger = null;
             /** @var \Cake\Database\Driver $driver */
             $driver = $connection->getDriver();
-            $driverConfig = $driver->config();
-            if ($driverConfig['sentryLog'] ?? false) {
-                $logger = $driver->getLogger();
+            if ($driver instanceof Driver) {
+                $driverConfig = $driver->config();
+                if ($driverConfig['sentryLog'] ?? false) {
+                    $logger = $driver->getLogger();
+                }
             }
 
             $logger = new CakeSentryLog($logger, $name, $includeSchemaReflection);


### PR DESCRIPTION
I’ve discovered an error when using CakePHP 5 and using elastic search
 
This results in the below error:
Fatal Error: Uncaught Error: Call to undefined method Elastica\Client::getLogger() in /vendor/lordsimal/cakephp-sentry/src/Http/SentryClient.php:62
 
This pull request ensures that it checks the Driver is actually a Driver before it tries to access this which is the same way CakePHP itself is doing.