### PR TITLE
fix stan

### DIFF
--- a/src/Http/SentryClient.php
+++ b/src/Http/SentryClient.php
@@ -57,7 +57,7 @@ class SentryClient implements EventDispatcherInterface
             if ($connection->configName() === 'debug_kit') {
                 continue;
             }
-            /** @var \Cake\Database\Driver $driver */
+            /** @var \Cake\Database\Driver|object $driver */
             $driver = $connection->getDriver();
             $logger = $driver->getLogger();
 

--- a/src/Middleware/CakeSentryPerformanceMiddleware.php
+++ b/src/Middleware/CakeSentryPerformanceMiddleware.php
@@ -119,7 +119,7 @@ class CakeSentryPerformanceMiddleware implements MiddlewareInterface
                 continue;
             }
             $logger = null;
-            /** @var \Cake\Database\Driver $driver */
+            /** @var \Cake\Database\Driver|object $driver */
             $driver = $connection->getDriver();
             $driverConfig = $driver->config();
             if ($driverConfig['sentryLog'] ?? false) {

--- a/src/Middleware/CakeSentryQueryMiddleware.php
+++ b/src/Middleware/CakeSentryQueryMiddleware.php
@@ -57,7 +57,7 @@ class CakeSentryQueryMiddleware implements MiddlewareInterface
                 continue;
             }
             $logger = null;
-            /** @var \Cake\Database\Driver $driver */
+            /** @var \Cake\Database\Driver|object $driver */
             $driver = $connection->getDriver();
             $driverConfig = $driver->config();
             if ($driverConfig['sentryLog'] ?? false) {
@@ -65,7 +65,9 @@ class CakeSentryQueryMiddleware implements MiddlewareInterface
             }
 
             $logger = new CakeSentryLog($logger, $name, $includeSchemaReflection);
-            $driver->setLogger($logger);
+            if (method_exists($driver, 'setLogger')) {
+                $driver->setLogger($logger);
+            }
         }
     }
 }


### PR DESCRIPTION
As reported in https://github.com/LordSimal/cakephp-sentry/pull/29 the Driver object may not always be a `\Cake\Database\Driver` [in the example of the elastic search plugin](https://github.com/cakephp/elastic-search/blob/4.x/src/Datasource/Connection.php#L272)

This fixes the stan problems reported with that change.