### PR TITLE
fix: Return early when elastic search provides no query object

### DIFF
--- a/src/Database/Log/CakeSentryLog.php
+++ b/src/Database/Log/CakeSentryLog.php
@@ -163,6 +163,10 @@ class CakeSentryLog extends AbstractLogger
      */
     public function log($level, string|Stringable $message, array $context = []): void
     {
+        // Return early when elastic search provides no query
+        if (empty($context['query'])){
+            return;
+        }
         /** @var \Cake\Database\Log\LoggedQuery $query */
         $query = $context['query'];
 


### PR DESCRIPTION
Elasticsearch does not return a LoggedQuery object when performance tracking is enabled. 

Currently results in a fatal error being produced - This PR fixes that. 

To track the Elasticsearch queries this would need a major refactoring. 