### PR TITLE
Avoid duplicate query breadcrumbs

### DIFF
--- a/src/Http/SentryClient.php
+++ b/src/Http/SentryClient.php
@@ -50,6 +50,7 @@ class SentryClient implements EventDispatcherInterface
      */
     protected function getQueryLoggers(): void
     {
+        $this->_loggers = [];
         $configs = ConnectionManager::configured();
         $includeSchemaReflection = (bool)Configure::read('CakeSentry.includeSchemaReflection');
 


### PR DESCRIPTION
Reset the discovered logger list before each capture so repeated captures do not replay SQL breadcrumbs.