### PR TITLE
Finish spans for rolled-back transactions

### DIFF
--- a/src/QuerySpanTrait.php
+++ b/src/QuerySpanTrait.php
@@ -39,12 +39,14 @@ trait QuerySpanTrait
             return;
         }
 
-        if ($context['query'] === 'COMMIT') {
+        if (in_array($context['query'], ['COMMIT', 'ROLLBACK'], true)) {
             $span = $this->popSpan();
 
             if ($span !== null) {
                 $span->finish();
-                $span->setStatus(SpanStatus::ok());
+                if ($context['query'] === 'COMMIT') {
+                    $span->setStatus(SpanStatus::ok());
+                }
             }
 
             return;


### PR DESCRIPTION
Treat ROLLBACK as a transaction-closing statement so the active span stack remains correct.