### PR TITLE
Clean up performance listeners after requests

### DIFF
--- a/src/EventListener.php
+++ b/src/EventListener.php
@@ -12,12 +12,21 @@ class EventListener implements EventListenerInterface
     use EventSpanTrait;
 
     /**
+     * @var array<string, mixed>|null
+     */
+    private ?array $events = null;
+
+    /**
      * Return an array of events to listen to.
      *
      * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {
+        if ($this->events !== null) {
+            return $this->events;
+        }
+
         $before = function (string $name): callable {
             return function () use ($name): void {
                 DebugTimer::start($name);
@@ -35,7 +44,7 @@ class EventListener implements EventListenerInterface
             ];
         };
 
-        return [
+        return $this->events = [
             'Controller.initialize' => [
                 ['priority' => 0, 'callable' => $before('Event: Controller.initialize')],
                 ['priority' => 999, 'callable' => $after('Event: Controller.initialize')],

--- a/src/Middleware/CakeSentryPerformanceMiddleware.php
+++ b/src/Middleware/CakeSentryPerformanceMiddleware.php
@@ -19,6 +19,7 @@ use Cake\Event\EventManager;
 use CakeSentry\Database\Log\CakeSentryLog;
 use CakeSentry\Event\CacheEventListener;
 use CakeSentry\Event\HttpEventListener;
+use CakeSentry\DebugTimer;
 use CakeSentry\EventListener;
 use CakeSentry\QuerySpanTrait;
 use Psr\Http\Message\ResponseInterface;
@@ -77,39 +78,52 @@ class CakeSentryPerformanceMiddleware implements MiddlewareInterface
         SentrySdk::getCurrentHub()->setSpan($span);
 
         $this->addQueryData();
+        $eventManager = EventManager::instance();
         $listener = new EventListener();
-        EventManager::instance()->on($listener);
-        EventManager::instance()->on(new HttpEventListener());
+        $httpListener = new HttpEventListener();
+        $eventManager->on($listener);
+        $eventManager->on($httpListener);
+        $cacheListener = null;
         if (class_exists('\Cake\Cache\Event\CacheAfterAddEvent')) {
-            EventManager::instance()->on(new CacheEventListener());
+            $cacheListener = new CacheEventListener();
+            $eventManager->on($cacheListener);
         }
 
-        $response = $handler->handle($request);
+        try {
+            $response = $handler->handle($request);
 
-        $listener->addSpans();
+            $listener->addSpans();
 
-        // We don't want to trace 404 responses as they are not relevant for performance monitoring.
-        if ($response->getStatusCode() === 404) {
-            $transaction->setSampled(false);
-        }
+            // We don't want to trace 404 responses as they are not relevant for performance monitoring.
+            if ($response->getStatusCode() === 404) {
+                $transaction->setSampled(false);
+            }
 
-        $span->setHttpStatus($response->getStatusCode());
-        $span->finish();
+            $span->setHttpStatus($response->getStatusCode());
+            $span->finish();
 
-        SentrySdk::getCurrentHub()->setSpan($transaction);
+            SentrySdk::getCurrentHub()->setSpan($transaction);
 
-        $transaction->setHttpStatus($response->getStatusCode());
+            $transaction->setHttpStatus($response->getStatusCode());
 
-        if (function_exists('fastcgi_finish_request')) {
-            // Send the transaction to sentry after the client has received the response
-            EventManager::instance()->on('Server.terminate', function () use ($transaction): void {
+            if (function_exists('fastcgi_finish_request')) {
+                // Send the transaction to sentry after the client has received the response
+                EventManager::instance()->on('Server.terminate', function () use ($transaction): void {
+                    $transaction->finish();
+                });
+            } else {
                 $transaction->finish();
-            });
-        } else {
-            $transaction->finish();
-        }
+            }
 
-        return $response;
+            return $response;
+        } finally {
+            $eventManager->off($listener);
+            $eventManager->off($httpListener);
+            if ($cacheListener !== null) {
+                $eventManager->off($cacheListener);
+            }
+            DebugTimer::clear();
+        }
     }
 
     /**


### PR DESCRIPTION
Detach temporary performance listeners and clear timers after every request, including exceptional paths. Cache callback mappings so EventManager can detach them reliably.