### PR TITLE
Forward context for error logs

### DIFF
--- a/src/Log/Engine/SentryLog.php
+++ b/src/Log/Engine/SentryLog.php
@@ -46,7 +46,7 @@ class SentryLog extends BaseLog
 
         match ($level) {
             LogLevel::EMERGENCY, LogLevel::ALERT, LogLevel::CRITICAL => $sentryLogger->fatal($message, [], $context),
-            LogLevel::ERROR => $sentryLogger->error($message),
+            LogLevel::ERROR => $sentryLogger->error($message, [], $context),
             LogLevel::WARNING => $sentryLogger->warn($message, [], $context),
             LogLevel::NOTICE, LogLevel::INFO => $sentryLogger->info($message, [], $context),
             LogLevel::DEBUG => $sentryLogger->debug($message, [], $context),

--- a/tests/TestCase/Log/Engine/SentryLogTest.php
+++ b/tests/TestCase/Log/Engine/SentryLogTest.php
@@ -76,7 +76,7 @@ class SentryLogTest extends TestCase
     {
         return [
             'warning' => [LogLevel::WARNING, LogLevel::WARNING, true],
-            'error' => [LogLevel::ERROR, LogLevel::ERROR, false],
+            'error' => [LogLevel::ERROR, LogLevel::ERROR, true],
             'notice' => [LogLevel::NOTICE, LogLevel::INFO, true],
             'debug' => [LogLevel::DEBUG, LogLevel::DEBUG, true],
             'emergency' => [LogLevel::EMERGENCY, LogLevel::CRITICAL, true],


### PR DESCRIPTION
Preserve structured CakePHP log context for error-level Sentry logs and cover the behavior with the existing log test.