### PR TITLE
Fix Sentry documentation examples

### DIFF
--- a/docs/guide/event-hooks.md
+++ b/docs/guide/event-hooks.md
@@ -45,9 +45,9 @@ class SentryOptionsContext implements EventListenerInterface
 
     public function setServerContext(Event $event): void
     {
-        /** @var \CakeSentry\Http\SentryClient $subject */
+        /** @var \Sentry\State\HubInterface $subject */
         $subject = $event->getSubject();
-        $options = $subject->getHub()->getClient()->getOptions();
+        $options = $subject->getClient()->getOptions();
 
         $options->setEnvironment('test_app');
         $options->setRelease('3.0.0@dev');

--- a/docs/guide/performance-monitoring.md
+++ b/docs/guide/performance-monitoring.md
@@ -11,12 +11,12 @@
 return [
     'CakeSentry' => [
         'enableQueryLogging' => true,
-        'enablePerformanceMonitoring' => true
-    ]
+        'enablePerformanceMonitoring' => true,
+    ],
     'Sentry' => [
         'dsn' => '<sentry-dsn-url>',
         'traces_sample_rate' => 1,
-    ]
+    ],
 ];
 ```
 
@@ -34,6 +34,7 @@ return [
             // ...
         ],
     ],
+];
 ```     
 
 :::


### PR DESCRIPTION
Correct the PHP configuration snippet and align the after-setup hook example with the Sentry Hub event subject.